### PR TITLE
doc: update release workflow docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- doc: update release workflow docs in `DEVELOPMENT.md` — action no longer commits CHANGELOG to main
+- fix(ci): remove `Finalize CHANGELOG` step from `release.yml` (already removed in v0.2.0)
+
 ## [0.2.1] - 2026-02-21
 
 ### Fixed

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -196,9 +196,10 @@ Runs on push/PR to `main`:
 
 Triggered by pushing a tag matching `v*`:
 1. Extracts version from the tag
-2. Finalizes `docs/CHANGELOG.md` (replaces `[Unreleased]` header with version + date)
-3. Commits the CHANGELOG update to `main`
-4. Creates a GitHub Release with notes extracted from the CHANGELOG
+2. Extracts release notes from `docs/CHANGELOG.md` (content under the version header)
+3. Creates a GitHub Release with the extracted notes
+
+**Note:** The CHANGELOG must be finalized (version header + compare links) *before* tagging. The action does not modify `docs/CHANGELOG.md` on `main`.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

- Update release workflow description in `DEVELOPMENT.md` — the action no longer commits CHANGELOG changes to main
- CHANGELOG finalization must now happen before tagging